### PR TITLE
updating np.concatenate calls (issue #4)

### DIFF
--- a/demos/trace_a16.py
+++ b/demos/trace_a16.py
@@ -20,7 +20,7 @@ a16s = xr.open_dataset("33RO20131223_bottle.nc")
 combined_length = len(a16n.N_PROF) * len(a16n.N_LEVELS) + len(
     a16s.N_PROF
 ) * len(a16s.N_LEVELS)
-latlist = np.concat(
+latlist = np.concatenate(
     [
         (
             np.ones((len(a16n.N_PROF), len(a16n.N_LEVELS)))
@@ -32,7 +32,7 @@ latlist = np.concat(
         ).ravel(),
     ]
 )
-lonlist = np.concat(
+lonlist = np.concatenate(
     [
         (
             np.ones((len(a16n.N_PROF), len(a16n.N_LEVELS)))
@@ -48,11 +48,11 @@ input_df = pd.DataFrame(
     {
         "lat": latlist,
         "lon": lonlist,
-        "pressure": np.concat(
+        "pressure": np.concatenate(
             [a16n.pressure.data.ravel(), a16s.pressure.data.ravel()]
         ),
         "year": np.ones((combined_length)) * 2013,
-        "sal": np.concat(
+        "sal": np.concatenate(
             [
                 a16n.bottle_salinity.where(
                     a16n.bottle_salinity_qc == 2
@@ -62,7 +62,7 @@ input_df = pd.DataFrame(
                 ).data.ravel(),
             ]
         ),
-        "temp": np.concat(
+        "temp": np.concatenate(
             [
                 a16n.ctd_temperature.data.ravel(),
                 a16s.ctd_temperature.data.ravel(),

--- a/pyTRACE/neuralnets/__init__.py
+++ b/pyTRACE/neuralnets/__init__.py
@@ -283,7 +283,7 @@ def trace_nn(
         L = io.loadmat(fn)
 
         output_estimates = np.full((output_coordinates.shape[0]), np.nan)
-        m = np.concat([C[:, 2][:, None], m[:, :]], axis=1)
+        m = np.concatenate([C[:, 2][:, None], m[:, :]], axis=1)
 
         est_atl = np.full((C.shape[0], 4), np.nan)
         est_other = np.full((C.shape[0], 4), np.nan)


### PR DESCRIPTION
changed occurrences of `np.concat` to `np.concatenate` to be back-compatible with numpy<v2